### PR TITLE
Is this 30 meters offset in depth scaling really necessary?

### DIFF
--- a/hyo2/ssm2/app/gui/soundspeedmanager/widgets/dataplots.py
+++ b/hyo2/ssm2/app/gui/soundspeedmanager/widgets/dataplots.py
@@ -689,7 +689,7 @@ class DataPlots(AbstractWidget):
                                 mean_sis_depth = self.lib.listeners.sis.xyz_mean_depth
                     max_proc_sis_depth = max(max_proc_depth, mean_sis_depth)
 
-                    max_depth = max(30. + max_proc_sis_depth, 1.1 * max_proc_sis_depth)
+                    max_depth = 1.1 * max_proc_sis_depth
                     min_depth = -0.05 * max_proc_sis_depth
                     if min_depth > 0:
                         min_depth = -5


### PR DESCRIPTION
Hi,

It has come to my attention that the depth scaling in the dataplots of the Editor tab is not optimal for displaying the sound speed profile. This is particularly annoying with the MVP listener. If the user manually changes the zoom level to inspect the latest sound speed profile, the next received profile will again be displayed with the sub-optimal depth scaling.

I traced back this sub-optimal depth scaling to a 30 meters offset. My question is: can we remove this 30 meters offset?

Here are screenshots of the depth scaling with and without the 30 meters offset. In this particular case, the sis depth is deeper than the profile depth, so the sis depth is used as max depth. Left, the result is max_depth + 30m offset. Right, it's 1.1 * max_depth.

<img width="594" height="400" alt="DepthScaling" src="https://github.com/user-attachments/assets/d6548c78-e38e-4a80-9d21-4eeebf359f76" />
